### PR TITLE
Initial Release Repository

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,118 @@
+name: merge
+
+on: pull_request
+
+env:
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: cargo build --all-targets --all-features
+  checks:
+    name: various checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: check formatting
+        run: cargo fmt --all -- --check
+
+      - name: clippy checks
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
+
+      - shell: bash
+        run: cargo install ripgrep
+      - uses: maidsafe/verify-licensing-info@main
+        name: verify licensing
+        with:
+          company-name: MaidSafe
+
+  cargo-udeps:
+    name: unused dependency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
+          args: '--all-targets'
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
+  tests:
+    name: unit test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
+
+  test-publish:
+    name: test publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: dry run publish
+        run: cargo publish --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+
+# Added by cargo
+
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
 chrono = "0.4.26"
 flate2 = "1.0"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,16 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.26"
+flate2 = "1.0"
 lazy_static = "1.4.0"
 regex = "1.10.2"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1.0"
+tar = "0.4.40"
 thiserror = "1.0.49"
 tokio = { version = "1.26", features = ["full"] }
+zip = "0.6.6"
+
+[dev-dependencies]
+assert_fs = "~1.0"
+predicates = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sn-releases"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = "0.4.26"
+lazy_static = "1.4.0"
+regex = "1.10.2"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+serde_json = "1.0"
+thiserror = "1.0.49"
+tokio = { version = "1.26", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # sn-releases
-Simple crate for downloading and unpacking released binaries for Safe projects
+
+Simple crate for downloading and unpacking binaries released from the [safe_network](https://github.com/maidsafe/safe_network) repository.
+
+## Example Usage
+
+```rust
+let temp_dir = TempDir::new("safenode")?;
+let pb = Arc::new(ProgressBar::new(0));
+pb.set_style(ProgressStyle::default_bar()
+    .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
+    .progress_chars("#>-"));
+let pb_clone = pb.clone();
+let callback: Box<dyn Fn(u64, u64) + Send + Sync> = Box::new(move |downloaded, total| {
+    pb_clone.set_length(total);
+    pb_clone.set_position(downloaded);
+});
+
+let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+let archive_path = release_repo
+    .download_release_from_s3(
+        &ReleaseType::Safenode,
+        "0.94.0",
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+        temp_dir.path(),
+        &callback,
+    )
+    .await?;
+
+pb.finish_with_message("Download complete");
+
+release_repo.extract_release_archive(&archive_path, temp_dir.path())?;
+```
+
+## Testing
+
+It's possible for users of the crate to program against the `SafeReleaseRepositoryInterface`, which can then be mocked and used in a unit test.
+
+```rust
+pub fn function_under_test(release_repo: Box<dyn SafeReleaseRepositoryInterface>) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::function_under_test;
+    use async_trait::async_trait;
+    use mockall::mock;
+    use mockall::predicate::*;
+    use sn_releases::{
+        ArchiveType, Platform, ProgressCallback, ReleaseType, Result as SnReleaseResult,
+        SafeReleaseRepositoryInterface,
+    };
+    use std::path::{Path, PathBuf};
+
+    mock! {
+        pub SafeReleaseRepository {}
+        #[async_trait]
+        impl SafeReleaseRepositoryInterface for SafeReleaseRepository {
+            async fn get_latest_version(&self, release_type: &ReleaseType) -> SnReleaseResult<String>;
+            async fn download_release_from_s3(
+                &self,
+                release_type: &ReleaseType,
+                version: &str,
+                platform: &Platform,
+                archive_type: &ArchiveType,
+                dest_path: &Path,
+                callback: &ProgressCallback,
+            ) -> SnReleaseResult<PathBuf>;
+            fn extract_release_archive(&self, archive_path: &Path, dest_dir_path: &Path)
+                -> SnReleaseResult<PathBuf>;
+        }
+    }
+
+    #[test]
+    fn test_release_repo() {
+        let release_type = ReleaseType::Safe;
+        let mut mock = MockSafeReleaseRepository::new();
+        mock.expect_get_latest_version()
+            .withf(move |arg| *arg == release_type)
+            .times(1)
+            .returning(|_| Ok("0.93.12".to_string()));
+        let result = function_under_test(Box::new(mock));
+        assert!(result.is_ok());
+    }
+}
+```

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 #[allow(missing_docs)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,10 +9,14 @@ pub enum Error {
     DateTimeParseError(#[from] chrono::ParseError),
     #[error("Could not convert API response header links to string")]
     HeaderLinksToStrError,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
     #[error("Latest release not found for {0}")]
     LatestReleaseNotFound(String),
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error("Could not parse version from tag name")]
     TagNameVersionParsingFailed,
+    #[error(transparent)]
+    ZipError(#[from] zip::result::ZipError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     LatestReleaseNotFound(String),
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
+    #[error("Release binary {0} was not found")]
+    ReleaseBinaryNotFound(String),
     #[error("Could not parse version from tag name")]
     TagNameVersionParsingFailed,
     #[error(transparent)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error(transparent)]
+    DateTimeParseError(#[from] chrono::ParseError),
+    #[error("Could not convert API response header links to string")]
+    HeaderLinksToStrError,
+    #[error("Latest release not found for {0}")]
+    LatestReleaseNotFound(String),
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Could not parse version from tag name")]
+    TagNameVersionParsingFailed,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,10 @@ impl SafeReleaseRepositoryInterface for SafeReleaseRepository {
         );
 
         let client = Client::new();
-        let mut response = client.get(&url).send().await.unwrap();
+        let mut response = client.get(&url).send().await?;
+        if !response.status().is_success() {
+            return Err(Error::ReleaseBinaryNotFound(url));
+        }
 
         let total_size = response
             .headers()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,157 @@
+pub mod error;
+
+use crate::error::{Error, Result};
+use chrono::{DateTime, Duration, Utc};
+use lazy_static::lazy_static;
+use reqwest::{header::HeaderMap, Client, Response};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
+
+const GITHUB_API_URL: &str = "https://api.github.com";
+const GITHUB_ORG_NAME: &str = "maidsafe";
+const GITHUB_REPO_NAME: &str = "safe_network";
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub enum ReleaseType {
+    Safe,
+    Safenode,
+    Testnet,
+}
+
+impl fmt::Display for ReleaseType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ReleaseType::Safe => "safe",
+                ReleaseType::Safenode => "safenode",
+                ReleaseType::Testnet => "testnet",
+            }
+        )
+    }
+}
+
+lazy_static! {
+    static ref RELEASE_TYPE_CRATE_NAME_MAP: HashMap<ReleaseType, &'static str> = {
+        let mut m = HashMap::new();
+        m.insert(ReleaseType::Safe, "sn_cli");
+        m.insert(ReleaseType::Safenode, "sn_node");
+        m.insert(ReleaseType::Testnet, "sn_testnet");
+        m
+    };
+}
+
+/// Gets the latest version for a specified binary in the `safe_network` repository.
+///
+/// Each release in the repository is checked, starting from the most recent. The `safe_network`
+/// repository is a workspace to which many binaries are released, so it's not possible to use the
+/// more straight forward Github API which simply returns the latest release, since that's going to
+/// be the version number for one of many binaries.
+///
+/// During the search, if a release is found that was created more than 14 days ago, the function
+/// will stop searching through older releases, which will avoid fetching further pages from the
+/// Github API.
+///
+/// # Arguments
+///
+/// * `release_type` - A reference to a `ReleaseType` enum specifying the type of release to look for.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a `String` with the latest version number in the semantic format.
+/// Otherwise, returns an `Error`.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The HTTP request to GitHub API fails
+/// - The received JSON data from the API is not as expected
+/// - No releases are found that match the specified `ReleaseType`
+pub async fn get_latest_version(release_type: &ReleaseType) -> Result<String> {
+    let mut page = 1;
+    let per_page = 100;
+    let mut latest_release: Option<(String, DateTime<Utc>)> = None;
+    let target_tag_name = *RELEASE_TYPE_CRATE_NAME_MAP.get(release_type).unwrap();
+    let now = Utc::now();
+
+    loop {
+        let response = get_releases_page(page, per_page).await?;
+        let headers = response.headers().clone();
+        let releases = response.json::<Value>().await?;
+
+        let mut continue_search = true;
+        if let Value::Array(releases) = releases {
+            for release in releases {
+                if let Value::Object(release) = release {
+                    if let (Some(Value::String(tag_name)), Some(Value::String(created_at))) =
+                        (release.get("tag_name"), release.get("created_at"))
+                    {
+                        let created_at = created_at.parse::<DateTime<Utc>>()?;
+                        if tag_name.starts_with(target_tag_name) {
+                            match latest_release {
+                                Some((_, date)) if created_at > date => {
+                                    latest_release = Some((tag_name.clone(), created_at));
+                                }
+                                None => {
+                                    latest_release = Some((tag_name.clone(), created_at));
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        if now.signed_duration_since(created_at) > Duration::days(14) {
+                            continue_search = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if continue_search && has_next_page(&headers).await? {
+            page += 1;
+        } else {
+            break;
+        }
+    }
+
+    let tag_name = latest_release
+        .ok_or_else(|| Error::LatestReleaseNotFound(release_type.to_string()))?
+        .0;
+    let version = get_version_from_tag_name(&tag_name)?;
+    Ok(version)
+}
+
+async fn get_releases_page(page: u32, per_page: u32) -> Result<Response> {
+    let client = Client::new();
+    let response = client
+        .get(format!(
+            "{}/repos/{}/{}/releases?page={}&per_page={}",
+            GITHUB_API_URL, GITHUB_ORG_NAME, GITHUB_REPO_NAME, page, per_page
+        ))
+        .header("User-Agent", "request")
+        .send()
+        .await?;
+    Ok(response)
+}
+
+async fn has_next_page(headers: &HeaderMap) -> Result<bool> {
+    if let Some(links) = headers.get("link") {
+        let links = links.to_str().map_err(|_| Error::HeaderLinksToStrError)?;
+        Ok(links.split(',').any(|link| link.contains("rel=\"next\"")))
+    } else {
+        Ok(false)
+    }
+}
+
+fn get_version_from_tag_name(tag_name: &str) -> Result<String> {
+    let mut parts = tag_name.split('-');
+    parts.next();
+    let version = parts
+        .next()
+        .ok_or_else(|| Error::TagNameVersionParsingFailed)?
+        .to_string();
+    Ok(version.trim_start_matches('v').to_string())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+pub use crate::error::{Error, Result};
+
 pub mod error;
 
-use crate::error::{Error, Result};
+use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use lazy_static::lazy_static;
 use reqwest::{header::HeaderMap, Client, Response};
@@ -16,8 +18,11 @@ use zip::ZipArchive;
 const GITHUB_API_URL: &str = "https://api.github.com";
 const GITHUB_ORG_NAME: &str = "maidsafe";
 const GITHUB_REPO_NAME: &str = "safe_network";
+const SAFE_S3_BASE_URL: &str = "https://sn-cli.s3.eu-west-2.amazonaws.com";
+const SAFENODE_S3_BASE_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
+const TESTNET_S3_BASE_URL: &str = "https://sn-testnet.s3.eu-west-2.amazonaws.com";
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ReleaseType {
     Safe,
     Safenode,
@@ -35,16 +40,6 @@ impl fmt::Display for ReleaseType {
                 ReleaseType::Testnet => "testnet",
             }
         )
-    }
-}
-
-impl ReleaseType {
-    pub fn get_base_url(&self) -> String {
-        match self {
-            ReleaseType::Safe => "https://sn-cli.s3.eu-west-2.amazonaws.com".to_string(),
-            ReleaseType::Safenode => "https://sn-node.s3.eu-west-2.amazonaws.com".to_string(),
-            ReleaseType::Testnet => "https://sn-testnet.s3.eu-west-2.amazonaws.com".to_string(),
-        }
     }
 }
 
@@ -96,237 +91,289 @@ impl fmt::Display for ArchiveType {
     }
 }
 
-type ProgressCallback = dyn Fn(u64, u64);
+pub type ProgressCallback = dyn Fn(u64, u64) + Send + Sync;
 
-/// Gets the latest version for a specified binary in the `safe_network` repository.
-///
-/// Each release in the repository is checked, starting from the most recent. The `safe_network`
-/// repository is a workspace to which many binaries are released, so it's not possible to use the
-/// more straight forward Github API which simply returns the latest release, since that's going to
-/// be the version number for one of many binaries.
-///
-/// During the search, if a release is found that was created more than 14 days ago, the function
-/// will stop searching through older releases, which will avoid fetching further pages from the
-/// Github API.
-///
-/// # Arguments
-///
-/// * `release_type` - A reference to a `ReleaseType` enum specifying the type of release to look for.
-///
-/// # Returns
-///
-/// Returns a `Result` containing a `String` with the latest version number in the semantic format.
-/// Otherwise, returns an `Error`.
-///
-/// # Errors
-///
-/// This function will return an error if:
-/// - The HTTP request to GitHub API fails
-/// - The received JSON data from the API is not as expected
-/// - No releases are found that match the specified `ReleaseType`
-pub async fn get_latest_version(release_type: &ReleaseType) -> Result<String> {
-    let mut page = 1;
-    let per_page = 100;
-    let mut latest_release: Option<(String, DateTime<Utc>)> = None;
-    let target_tag_name = *RELEASE_TYPE_CRATE_NAME_MAP.get(release_type).unwrap();
-    let now = Utc::now();
+#[async_trait]
+pub trait SafeReleaseRepositoryInterface {
+    async fn get_latest_version(&self, release_type: &ReleaseType) -> Result<String>;
+    async fn download_release_from_s3(
+        &self,
+        release_type: &ReleaseType,
+        version: &str,
+        platform: &Platform,
+        archive_type: &ArchiveType,
+        dest_path: &Path,
+        callback: &ProgressCallback,
+    ) -> Result<PathBuf>;
+    fn extract_release_archive(&self, archive_path: &Path, dest_dir_path: &Path)
+        -> Result<PathBuf>;
+}
 
-    loop {
-        let response = get_releases_page(page, per_page).await?;
-        let headers = response.headers().clone();
-        let releases = response.json::<Value>().await?;
+impl dyn SafeReleaseRepositoryInterface {
+    pub fn default_config() -> Box<dyn SafeReleaseRepositoryInterface> {
+        Box::new(SafeReleaseRepository {
+            github_api_base_url: GITHUB_API_URL.to_string(),
+            safe_base_url: SAFE_S3_BASE_URL.to_string(),
+            safenode_base_url: SAFENODE_S3_BASE_URL.to_string(),
+            testnet_base_url: TESTNET_S3_BASE_URL.to_string(),
+        })
+    }
+}
 
-        let mut continue_search = true;
-        if let Value::Array(releases) = releases {
-            for release in releases {
-                if let Value::Object(release) = release {
-                    if let (Some(Value::String(tag_name)), Some(Value::String(created_at))) =
-                        (release.get("tag_name"), release.get("created_at"))
-                    {
-                        let created_at = created_at.parse::<DateTime<Utc>>()?;
-                        if tag_name.starts_with(target_tag_name) {
-                            match latest_release {
-                                Some((_, date)) if created_at > date => {
-                                    latest_release = Some((tag_name.clone(), created_at));
+pub struct SafeReleaseRepository {
+    pub github_api_base_url: String,
+    pub safe_base_url: String,
+    pub safenode_base_url: String,
+    pub testnet_base_url: String,
+}
+
+impl SafeReleaseRepository {
+    fn get_base_url(&self, release_type: &ReleaseType) -> String {
+        match release_type {
+            ReleaseType::Safe => self.safe_base_url.clone(),
+            ReleaseType::Safenode => self.safenode_base_url.clone(),
+            ReleaseType::Testnet => self.testnet_base_url.clone(),
+        }
+    }
+
+    async fn get_releases_page(&self, page: u32, per_page: u32) -> Result<Response> {
+        let client = Client::new();
+        let response = client
+            .get(format!(
+                "{}/repos/{}/{}/releases?page={}&per_page={}",
+                self.github_api_base_url, GITHUB_ORG_NAME, GITHUB_REPO_NAME, page, per_page
+            ))
+            .header("User-Agent", "request")
+            .send()
+            .await?;
+        Ok(response)
+    }
+
+    async fn has_next_page(&self, headers: &HeaderMap) -> Result<bool> {
+        if let Some(links) = headers.get("link") {
+            let links = links.to_str().map_err(|_| Error::HeaderLinksToStrError)?;
+            Ok(links.split(',').any(|link| link.contains("rel=\"next\"")))
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn get_version_from_tag_name(&self, tag_name: &str) -> Result<String> {
+        let mut parts = tag_name.split('-');
+        parts.next();
+        let version = parts
+            .next()
+            .ok_or_else(|| Error::TagNameVersionParsingFailed)?
+            .to_string();
+        Ok(version.trim_start_matches('v').to_string())
+    }
+}
+
+#[async_trait]
+impl SafeReleaseRepositoryInterface for SafeReleaseRepository {
+    /// Gets the latest version for a specified binary in the `safe_network` repository.
+    ///
+    /// Each release in the repository is checked, starting from the most recent. The `safe_network`
+    /// repository is a workspace to which many binaries are released, so it's not possible to use the
+    /// more straight forward Github API which simply returns the latest release, since that's going to
+    /// be the version number for one of many binaries.
+    ///
+    /// During the search, if a release is found that was created more than 14 days ago, the function
+    /// will stop searching through older releases, which will avoid fetching further pages from the
+    /// Github API.
+    ///
+    /// # Arguments
+    ///
+    /// * `release_type` - A reference to a `ReleaseType` enum specifying the type of release to look for.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing a `String` with the latest version number in the semantic format.
+    /// Otherwise, returns an `Error`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The HTTP request to GitHub API fails
+    /// - The received JSON data from the API is not as expected
+    /// - No releases are found that match the specified `ReleaseType`
+    async fn get_latest_version(&self, release_type: &ReleaseType) -> Result<String> {
+        let mut page = 1;
+        let per_page = 100;
+        let mut latest_release: Option<(String, DateTime<Utc>)> = None;
+        let target_tag_name = *RELEASE_TYPE_CRATE_NAME_MAP.get(release_type).unwrap();
+        let now = Utc::now();
+
+        loop {
+            let response = self.get_releases_page(page, per_page).await?;
+            let headers = response.headers().clone();
+            let releases = response.json::<Value>().await?;
+
+            let mut continue_search = true;
+            if let Value::Array(releases) = releases {
+                for release in releases {
+                    if let Value::Object(release) = release {
+                        if let (Some(Value::String(tag_name)), Some(Value::String(created_at))) =
+                            (release.get("tag_name"), release.get("created_at"))
+                        {
+                            let created_at = created_at.parse::<DateTime<Utc>>()?;
+                            if tag_name.starts_with(target_tag_name) {
+                                match latest_release {
+                                    Some((_, date)) if created_at > date => {
+                                        latest_release = Some((tag_name.clone(), created_at));
+                                    }
+                                    None => {
+                                        latest_release = Some((tag_name.clone(), created_at));
+                                    }
+                                    _ => {}
                                 }
-                                None => {
-                                    latest_release = Some((tag_name.clone(), created_at));
-                                }
-                                _ => {}
                             }
-                        }
 
-                        if now.signed_duration_since(created_at) > Duration::days(14) {
-                            continue_search = false;
-                            break;
+                            if now.signed_duration_since(created_at) > Duration::days(14) {
+                                continue_search = false;
+                                break;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        if continue_search && has_next_page(&headers).await? {
-            page += 1;
-        } else {
-            break;
-        }
-    }
-
-    let tag_name = latest_release
-        .ok_or_else(|| Error::LatestReleaseNotFound(release_type.to_string()))?
-        .0;
-    let version = get_version_from_tag_name(&tag_name)?;
-    Ok(version)
-}
-
-/// Downloads a release binary archive from S3.
-///
-/// # Arguments
-///
-/// - `release_type`: The type of release.
-/// - `version`: The version of the release.
-/// - `platform`: The target platform.
-/// - `archive_type`: The type of archive (e.g., tar.gz, zip).
-/// - `dest_path`: The directory where the downloaded archive will be stored.
-/// - `callback`: A callback function that can be used for download progress.
-///
-/// # Returns
-///
-/// A `Result` with `PathBuf` indicating the full path of the downloaded archive, or an error if
-/// the download or file write operation fails.
-pub async fn download_release_from_s3(
-    release_type: &ReleaseType,
-    version: &str,
-    platform: &Platform,
-    archive_type: &ArchiveType,
-    dest_path: &Path,
-    callback: &ProgressCallback,
-) -> Result<PathBuf> {
-    let archive_ext = archive_type.to_string();
-    let url = format!(
-        "{}/{}-{}-{}.{}",
-        release_type.get_base_url(),
-        release_type.to_string().to_lowercase(),
-        version,
-        platform.to_string(),
-        archive_type.to_string()
-    );
-
-    let client = Client::new();
-    let mut response = client.get(&url).send().await.unwrap();
-
-    let total_size = response
-        .headers()
-        .get("content-length")
-        .and_then(|ct_len| ct_len.to_str().ok())
-        .and_then(|ct_len| ct_len.parse::<u64>().ok())
-        .unwrap_or(0);
-
-    let mut downloaded: u64 = 0;
-    let archive_name = format!(
-        "{}-{}-{}.{}",
-        release_type.to_string().to_lowercase(),
-        version,
-        platform.to_string(),
-        archive_ext
-    );
-    let archive_path = dest_path.join(archive_name);
-    let mut out_file = File::create(&archive_path).await?;
-
-    while let Some(chunk) = response.chunk().await.unwrap() {
-        downloaded += chunk.len() as u64;
-        out_file.write_all(&chunk).await?;
-        callback(downloaded, total_size);
-    }
-
-    Ok(archive_path)
-}
-
-/// Extracts a release binary archive.
-///
-/// The archive will include a single binary file.
-///
-/// # Arguments
-///
-/// - `archive_path`: The path of the archive file to extract.
-/// - `dest_dir`: The directory where the archive should be extracted.
-///
-/// # Returns
-///
-/// A `Result` with `PathBuf` indicating the full path of the extracted binary.
-pub fn extract_release_archive(archive_path: &Path, dest_dir_path: &Path) -> Result<PathBuf> {
-    if !archive_path.exists() {
-        return Err(Error::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("Archive not found at: {:?}", archive_path),
-        )));
-    }
-
-    if archive_path.extension() == Some(std::ffi::OsStr::new("gz")) {
-        let archive_file = std::fs::File::open(archive_path)?;
-        let tarball = flate2::read::GzDecoder::new(archive_file);
-        let mut archive = Archive::new(tarball);
-        for file in archive.entries()? {
-            let mut file = file?;
-            let out_path = dest_dir_path.join(file.path()?);
-            file.unpack(&out_path)?;
-            return Ok(out_path);
-        }
-    } else if archive_path.extension() == Some(std::ffi::OsStr::new("zip")) {
-        let archive_file = std::fs::File::open(archive_path)?;
-        let mut archive = ZipArchive::new(archive_file)?;
-        for i in 0..archive.len() {
-            let mut file = archive.by_index(i)?;
-            let out_path = dest_dir_path.join(file.name());
-            if file.name().ends_with('/') {
-                std::fs::create_dir_all(&out_path)?;
+            if continue_search && self.has_next_page(&headers).await? {
+                page += 1;
             } else {
-                let mut outfile = std::fs::File::create(&out_path)?;
-                std::io::copy(&mut file, &mut outfile)?;
+                break;
             }
-            return Ok(out_path);
         }
-    } else {
-        return Err(Error::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Unsupported archive format",
-        )));
+
+        let tag_name = latest_release
+            .ok_or_else(|| Error::LatestReleaseNotFound(release_type.to_string()))?
+            .0;
+        let version = self.get_version_from_tag_name(&tag_name)?;
+        Ok(version)
     }
 
-    Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "Failed to extract archive",
-    )))
-}
+    /// Downloads a release binary archive from S3.
+    ///
+    /// # Arguments
+    ///
+    /// - `release_type`: The type of release.
+    /// - `version`: The version of the release.
+    /// - `platform`: The target platform.
+    /// - `archive_type`: The type of archive (e.g., tar.gz, zip).
+    /// - `dest_path`: The directory where the downloaded archive will be stored.
+    /// - `callback`: A callback function that can be used for download progress.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` with `PathBuf` indicating the full path of the downloaded archive, or an error if
+    /// the download or file write operation fails.
+    async fn download_release_from_s3(
+        &self,
+        release_type: &ReleaseType,
+        version: &str,
+        platform: &Platform,
+        archive_type: &ArchiveType,
+        dest_path: &Path,
+        callback: &ProgressCallback,
+    ) -> Result<PathBuf> {
+        let archive_ext = archive_type.to_string();
+        let url = format!(
+            "{}/{}-{}-{}.{}",
+            self.get_base_url(release_type),
+            release_type.to_string().to_lowercase(),
+            version,
+            platform,
+            archive_type
+        );
 
-async fn get_releases_page(page: u32, per_page: u32) -> Result<Response> {
-    let client = Client::new();
-    let response = client
-        .get(format!(
-            "{}/repos/{}/{}/releases?page={}&per_page={}",
-            GITHUB_API_URL, GITHUB_ORG_NAME, GITHUB_REPO_NAME, page, per_page
-        ))
-        .header("User-Agent", "request")
-        .send()
-        .await?;
-    Ok(response)
-}
+        let client = Client::new();
+        let mut response = client.get(&url).send().await.unwrap();
 
-async fn has_next_page(headers: &HeaderMap) -> Result<bool> {
-    if let Some(links) = headers.get("link") {
-        let links = links.to_str().map_err(|_| Error::HeaderLinksToStrError)?;
-        Ok(links.split(',').any(|link| link.contains("rel=\"next\"")))
-    } else {
-        Ok(false)
+        let total_size = response
+            .headers()
+            .get("content-length")
+            .and_then(|ct_len| ct_len.to_str().ok())
+            .and_then(|ct_len| ct_len.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        let mut downloaded: u64 = 0;
+        let archive_name = format!(
+            "{}-{}-{}.{}",
+            release_type.to_string().to_lowercase(),
+            version,
+            platform,
+            archive_ext
+        );
+        let archive_path = dest_path.join(archive_name);
+        let mut out_file = File::create(&archive_path).await?;
+
+        while let Some(chunk) = response.chunk().await.unwrap() {
+            downloaded += chunk.len() as u64;
+            out_file.write_all(&chunk).await?;
+            callback(downloaded, total_size);
+        }
+
+        Ok(archive_path)
     }
-}
 
-fn get_version_from_tag_name(tag_name: &str) -> Result<String> {
-    let mut parts = tag_name.split('-');
-    parts.next();
-    let version = parts
-        .next()
-        .ok_or_else(|| Error::TagNameVersionParsingFailed)?
-        .to_string();
-    Ok(version.trim_start_matches('v').to_string())
+    /// Extracts a release binary archive.
+    ///
+    /// The archive will include a single binary file.
+    ///
+    /// # Arguments
+    ///
+    /// - `archive_path`: The path of the archive file to extract.
+    /// - `dest_dir`: The directory where the archive should be extracted.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` with `PathBuf` indicating the full path of the extracted binary.
+    fn extract_release_archive(
+        &self,
+        archive_path: &Path,
+        dest_dir_path: &Path,
+    ) -> Result<PathBuf> {
+        if !archive_path.exists() {
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Archive not found at: {:?}", archive_path),
+            )));
+        }
+
+        if archive_path.extension() == Some(std::ffi::OsStr::new("gz")) {
+            let archive_file = std::fs::File::open(archive_path)?;
+            let tarball = flate2::read::GzDecoder::new(archive_file);
+            let mut archive = Archive::new(tarball);
+            if let Some(file) = (archive.entries()?).next() {
+                let mut file = file?;
+                let out_path = dest_dir_path.join(file.path()?);
+                file.unpack(&out_path)?;
+                return Ok(out_path);
+            }
+        } else if archive_path.extension() == Some(std::ffi::OsStr::new("zip")) {
+            let archive_file = std::fs::File::open(archive_path)?;
+            let mut archive = ZipArchive::new(archive_file)?;
+            if let Some(i) = (0..archive.len()).next() {
+                let mut file = archive.by_index(i)?;
+                let out_path = dest_dir_path.join(file.name());
+                if file.name().ends_with('/') {
+                    std::fs::create_dir_all(&out_path)?;
+                } else {
+                    let mut outfile = std::fs::File::create(&out_path)?;
+                    std::io::copy(&mut file, &mut outfile)?;
+                }
+                return Ok(out_path);
+            }
+        } else {
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Unsupported archive format",
+            )));
+        }
+
+        Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to extract archive",
+        )))
+    }
 }

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -1,0 +1,260 @@
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use sn_releases::{
+    download_release_from_s3, extract_release_archive, ArchiveType, Platform, ReleaseType,
+};
+
+const SAFE_VERSION: &str = "0.83.51";
+const SAFENODE_VERSION: &str = "0.93.7";
+const TESTNET_VERSION: &str = "0.2.213";
+
+async fn download_and_extract(
+    release_type: &ReleaseType,
+    version: &str,
+    platform: &Platform,
+    archive_type: &ArchiveType,
+) {
+    let dest_dir = assert_fs::TempDir::new().unwrap().into_persistent();
+    let download_dir = dest_dir.child("download_to");
+    download_dir.create_dir_all().unwrap();
+    let extract_dir = dest_dir.child("extract_to");
+    extract_dir.create_dir_all().unwrap();
+
+    let progress_callback = |_downloaded: u64, _total: u64| {};
+
+    let archive_path = download_release_from_s3(
+        release_type,
+        version,
+        platform,
+        archive_type,
+        &download_dir.to_path_buf(),
+        &progress_callback,
+    )
+    .await
+    .unwrap();
+
+    let extracted_path =
+        extract_release_archive(&archive_path, &extract_dir.to_path_buf()).unwrap();
+
+    let binary_name = match release_type {
+        ReleaseType::Safe => "safe",
+        ReleaseType::Safenode => "safenode",
+        ReleaseType::Testnet => "testnet",
+    };
+    let expected_binary_name = if *platform == Platform::Windows {
+        format!("{}.exe", binary_name)
+    } else {
+        binary_name.to_string()
+    };
+
+    let binary_path = extract_dir.child(expected_binary_name);
+    binary_path.assert(predicate::path::is_file());
+    assert_eq!(binary_path.to_path_buf(), extracted_path);
+}
+
+///
+/// Safe Tests
+///
+#[tokio::test]
+async fn should_download_and_extract_safe_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::Safe,
+        SAFE_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safe_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::Safe,
+        SAFE_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safe_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::Safe,
+        SAFE_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safe_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::Safe,
+        SAFE_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safe_for_macos() {
+    download_and_extract(
+        &ReleaseType::Safe,
+        SAFE_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safe_for_windows() {
+    download_and_extract(
+        &ReleaseType::Safe,
+        SAFE_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}
+
+///
+/// Safenode Tests
+///
+#[tokio::test]
+async fn should_download_and_extract_safenode_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::Safenode,
+        SAFENODE_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::Safenode,
+        SAFENODE_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::Safenode,
+        SAFENODE_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::Safenode,
+        SAFENODE_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_for_macos() {
+    download_and_extract(
+        &ReleaseType::Safenode,
+        SAFENODE_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_for_windows() {
+    download_and_extract(
+        &ReleaseType::Safenode,
+        SAFENODE_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}
+
+///
+/// Testnet Tests
+///
+#[tokio::test]
+async fn should_download_and_extract_testnet_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::Testnet,
+        TESTNET_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_testnet_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::Testnet,
+        TESTNET_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_testnet_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::Testnet,
+        TESTNET_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_testnet_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::Testnet,
+        TESTNET_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_testnet_for_macos() {
+    download_and_extract(
+        &ReleaseType::Testnet,
+        TESTNET_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_testnet_for_windows() {
+    download_and_extract(
+        &ReleaseType::Testnet,
+        TESTNET_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -8,21 +8,21 @@ fn valid_semver_format(version: &str) -> bool {
 }
 
 #[tokio::test]
-async fn test_get_latest_version_safe() {
+async fn should_get_latest_version_of_safe() {
     let release_type = ReleaseType::Safe;
     let version = get_latest_version(&release_type).await.unwrap();
     assert!(valid_semver_format(&version));
 }
 
 #[tokio::test]
-async fn test_get_latest_version_safenode() {
+async fn should_get_latest_version_of_safenode() {
     let release_type = ReleaseType::Safenode;
     let version = get_latest_version(&release_type).await.unwrap();
     assert!(valid_semver_format(&version));
 }
 
 #[tokio::test]
-async fn test_get_latest_version_testnet() {
+async fn should_get_latest_version_of_testnet() {
     let release_type = ReleaseType::Testnet;
     let version = get_latest_version(&release_type).await.unwrap();
     assert!(valid_semver_format(&version));

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
-use sn_releases::{get_latest_version, ReleaseType};
-use tokio;
+use sn_releases::{ReleaseType, SafeReleaseRepositoryInterface};
 
 fn valid_semver_format(version: &str) -> bool {
     let re = Regex::new(r"^\d+\.\d+\.\d+$").unwrap();
@@ -10,20 +9,32 @@ fn valid_semver_format(version: &str) -> bool {
 #[tokio::test]
 async fn should_get_latest_version_of_safe() {
     let release_type = ReleaseType::Safe;
-    let version = get_latest_version(&release_type).await.unwrap();
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
     assert!(valid_semver_format(&version));
 }
 
 #[tokio::test]
 async fn should_get_latest_version_of_safenode() {
     let release_type = ReleaseType::Safenode;
-    let version = get_latest_version(&release_type).await.unwrap();
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
     assert!(valid_semver_format(&version));
 }
 
 #[tokio::test]
 async fn should_get_latest_version_of_testnet() {
     let release_type = ReleaseType::Testnet;
-    let version = get_latest_version(&release_type).await.unwrap();
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
     assert!(valid_semver_format(&version));
 }

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -1,0 +1,29 @@
+use regex::Regex;
+use sn_releases::{get_latest_version, ReleaseType};
+use tokio;
+
+fn valid_semver_format(version: &str) -> bool {
+    let re = Regex::new(r"^\d+\.\d+\.\d+$").unwrap();
+    re.is_match(version)
+}
+
+#[tokio::test]
+async fn test_get_latest_version_safe() {
+    let release_type = ReleaseType::Safe;
+    let version = get_latest_version(&release_type).await.unwrap();
+    assert!(valid_semver_format(&version));
+}
+
+#[tokio::test]
+async fn test_get_latest_version_safenode() {
+    let release_type = ReleaseType::Safenode;
+    let version = get_latest_version(&release_type).await.unwrap();
+    assert!(valid_semver_format(&version));
+}
+
+#[tokio::test]
+async fn test_get_latest_version_testnet() {
+    let release_type = ReleaseType::Testnet;
+    let version = get_latest_version(&release_type).await.unwrap();
+    assert!(valid_semver_format(&version));
+}


### PR DESCRIPTION
- 39c75fc **feat: provide `get_latest_version` function**

  Gets the latest version of a given binary released in the `safe_network` repository. Since the
  `safe_network` is a workspace repo where many binaries are releases, we can't use the more straight
  forward 'get latest release' API, since the version number on that relates to one of many binaries.

  As mentioned in the doc comments, we are trying to limit the search to releases that occur within
  the last 14 days. The `safe_network` repo currently has over 840 releases, so searching through the
  whole list means fetching many pages from Github, which can actually be quite slow.

  I made the decision to integration test rather than unit test, because the latter would involve
  setting up tedious mock responses, and the code really shouldn't change very much over time. We can
  use `--test-threads 1` in CI to try and mitigate rate-limiting errors.

- 35b67ac **feat: provide download and extract functions**

  Since the release archive files are always public, we can download from S3 using HTTPs rather than
  using an AWS API.

  It seems like it's worth having two separate functions since they could potentially evolve
  or change independently of one another.

  Integration tests are provided that cover most scenarios, but not all of them. The full matrix of
  tests would include covering each binary, each platform type and each archive type, which would be 3
  x 6 x 2. There are a couple of zip types in there, which goes through both of the extract paths, so
  that seems reasonable coverage to me. Since we're downloading from S3 and not Github, these tests
  shouldn't be subject to rate limiting problems.

- 6b4569d **refactor: move functions into trait/struct**

  The trait will allow users of the crate to unit test by programming against the trait rather than
  the concrete type.

  All the tests are passing after the refactor.

  Also fixed a few Clippy issues.

- 5897510 **docs: example usage and testing**

  Provide some simple examples that should demonstrate how to use the crate to retrieve binaries and
  how to mock the repository interface for a unit test.

- e98c45d **chore: downloading failure case**

  When I attempted to use the crate in the node manager, I discovered that it didn't result in a
  failure when passed a combination of values that would not result in a valid binary URL. We need to
  explicitly check the response for a non-success code.

- e79fe88 **ci: provide basic merge workflow**

  This is just copied from another repo. At this point, it includes licensing verification, which
  should fail on the next PR. This will force the addition of licensing.