### PR TITLE
feat: provide function to get platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "Download and unpack binaries released from the safe_network repos
 license = "GPL-3.0"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/maidsafe/sn-releases"
 
 [dependencies]
 async-trait = "0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("Latest release not found for {0}")]
     LatestReleaseNotFound(String),
+    #[error("{0}")]
+    PlatformNotSupported(String),
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error("Release binary {0} was not found")]


### PR DESCRIPTION
This will be required by callers so that they can download binaries based on their currently running platform.