### PR TITLE
chore: apply debug attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl fmt::Display for Platform {
     }
 }
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ArchiveType {
     TarGz,
     Zip,


### PR DESCRIPTION
Not having this is making things more difficult when referencing this type from other crates.