### PR TITLE
feat: support `sn_node_rpc_client` release type

### DIFF
--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -13,6 +13,7 @@ use sn_releases::{ArchiveType, Platform, ReleaseType, SafeReleaseRepositoryInter
 
 const SAFE_VERSION: &str = "0.83.51";
 const SAFENODE_VERSION: &str = "0.93.7";
+const SAFENODE_RPC_CLIENT_VERSION: &str = "0.1.40";
 const TESTNET_VERSION: &str = "0.2.213";
 
 async fn download_and_extract(
@@ -49,6 +50,7 @@ async fn download_and_extract(
     let binary_name = match release_type {
         ReleaseType::Safe => "safe",
         ReleaseType::Safenode => "safenode",
+        ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
         ReleaseType::Testnet => "testnet",
     };
     let expected_binary_name = if *platform == Platform::Windows {
@@ -296,6 +298,75 @@ async fn should_download_and_extract_testnet_for_windows() {
     download_and_extract(
         &ReleaseType::Testnet,
         TESTNET_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}
+
+///
+/// Safenode RPC client tests
+///
+#[tokio::test]
+async fn should_download_and_extract_safenode_rpc_client_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::SafenodeRpcClient,
+        SAFENODE_RPC_CLIENT_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_rpc_client_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::SafenodeRpcClient,
+        SAFENODE_RPC_CLIENT_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_rpc_client_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::SafenodeRpcClient,
+        SAFENODE_RPC_CLIENT_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_rpc_client_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::SafenodeRpcClient,
+        SAFENODE_RPC_CLIENT_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_rpc_client_for_macos() {
+    download_and_extract(
+        &ReleaseType::SafenodeRpcClient,
+        SAFENODE_RPC_CLIENT_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_rpc_client_for_windows() {
+    download_and_extract(
+        &ReleaseType::SafenodeRpcClient,
+        SAFENODE_RPC_CLIENT_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -37,6 +37,17 @@ async fn should_get_latest_version_of_safenode() {
 }
 
 #[tokio::test]
+async fn should_get_latest_version_of_safenode_rpc_client() {
+    let release_type = ReleaseType::SafenodeRpcClient;
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
+    assert!(valid_semver_format(&version));
+}
+
+#[tokio::test]
 async fn should_get_latest_version_of_testnet() {
     let release_type = ReleaseType::Testnet;
     let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();


### PR DESCRIPTION
The new binary is added to the available release types.

The addition of this binary also caused the incorrect latest version to be returned for `sn_node` because it was doing a starts-with match. The match was changed to compare the whole crate name.