### PR TITLE
feat: function for downloading custom url

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error(transparent)]
     DateTimeParseError(#[from] chrono::ParseError),
+    #[error("Cannot parse file name from the URL")]
+    CannotParseFilenameFromUrl,
     #[error("Could not convert API response header links to string")]
     HeaderLinksToStrError,
     #[error(transparent)]
@@ -29,6 +31,8 @@ pub enum Error {
     ReleaseBinaryNotFound(String),
     #[error("Could not parse version from tag name")]
     TagNameVersionParsingFailed,
+    #[error("The URL must point to a zip or gzipped tar archive")]
+    UrlIsNotArchive,
     #[error(transparent)]
     ZipError(#[from] zip::result::ZipError),
 }

--- a/tests/download_url.rs
+++ b/tests/download_url.rs
@@ -1,0 +1,57 @@
+// Copyright (C) 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use assert_fs::prelude::*;
+use sn_releases::error::Error;
+use sn_releases::SafeReleaseRepositoryInterface;
+
+#[tokio::test]
+async fn should_download_a_custom_binary() {
+    let dest_dir = assert_fs::TempDir::new().unwrap();
+    let download_dir = dest_dir.child("download_to");
+    download_dir.create_dir_all().unwrap();
+    let downloaded_archive =
+        download_dir.child("safenode-charlie-x86_64-unknown-linux-musl.tar.gz");
+
+    let url = "https://sn-node.s3.eu-west-2.amazonaws.com/jacderida/file-upload-address/safenode-charlie-x86_64-unknown-linux-musl.tar.gz";
+    let progress_callback = |_downloaded: u64, _total: u64| {};
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    release_repo
+        .download_release(url, &download_dir, &progress_callback)
+        .await
+        .unwrap();
+
+    downloaded_archive.assert(predicates::path::is_file());
+}
+
+#[tokio::test]
+async fn should_fail_to_download_non_archive() {
+    let dest_dir = assert_fs::TempDir::new().unwrap();
+    let download_dir = dest_dir.child("download_to");
+    download_dir.create_dir_all().unwrap();
+
+    let url = "https://sn-node.s3.eu-west-2.amazonaws.com/jacderida/file-upload-address/safenode-charlie-x86_64-unknown-linux-musl.txt";
+    let progress_callback = |_downloaded: u64, _total: u64| {};
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let result = release_repo
+        .download_release(url, &download_dir, &progress_callback)
+        .await;
+
+    match result {
+        Ok(_) => panic!("This test should result in a failure"),
+        Err(e) => match e {
+            Error::UrlIsNotArchive => {
+                assert_eq!(
+                    e.to_string(),
+                    "The URL must point to a zip or gzipped tar archive"
+                );
+            }
+            _ => panic!("The error type should be ReleaseBinaryNotFound"),
+        },
+    }
+}


### PR DESCRIPTION
In the node manager we want to support downloading a 'custom' binary, which is really a binary of `safenode` from someone's fork. These get uploaded and used during testnet deployments. This new function downloads the URL not on the basis of a convention, but instead just allowing any URL to be specified.

We make the assertion that the URL has to point to a zip or gzipped tar file.