### PR TITLE
feat: support node manager releases

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,16 +13,18 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error(transparent)]
-    DateTimeParseError(#[from] chrono::ParseError),
     #[error("Cannot parse file name from the URL")]
     CannotParseFilenameFromUrl,
+    #[error(transparent)]
+    DateTimeParseError(#[from] chrono::ParseError),
     #[error("Could not convert API response header links to string")]
     HeaderLinksToStrError,
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("Latest release not found for {0}")]
     LatestReleaseNotFound(String),
+    #[error("The Github API's latest release response document was not in the expected format")]
+    MalformedLatestReleaseResponse,
     #[error("{0}")]
     PlatformNotSupported(String),
     #[error(transparent)]

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -13,6 +13,7 @@ use sn_releases::{ArchiveType, Platform, ReleaseType, SafeReleaseRepositoryInter
 
 const SAFE_VERSION: &str = "0.83.51";
 const SAFENODE_VERSION: &str = "0.93.7";
+const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
 const SAFENODE_RPC_CLIENT_VERSION: &str = "0.1.40";
 const TESTNET_VERSION: &str = "0.2.213";
 
@@ -50,6 +51,7 @@ async fn download_and_extract(
     let binary_name = match release_type {
         ReleaseType::Safe => "safe",
         ReleaseType::Safenode => "safenode",
+        ReleaseType::SafenodeManager => "safenode-manager",
         ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
         ReleaseType::Testnet => "testnet",
     };
@@ -367,6 +369,75 @@ async fn should_download_and_extract_safenode_rpc_client_for_windows() {
     download_and_extract(
         &ReleaseType::SafenodeRpcClient,
         SAFENODE_RPC_CLIENT_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}
+
+///
+/// Node Manager Tests
+///
+#[tokio::test]
+async fn should_download_and_extract_safenode_manager_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::SafenodeManager,
+        SAFENODE_MANAGER_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_manager_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::SafenodeManager,
+        SAFENODE_MANAGER_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_manager_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::SafenodeManager,
+        SAFENODE_MANAGER_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_manager_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::SafenodeManager,
+        SAFENODE_MANAGER_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_manager_for_macos() {
+    download_and_extract(
+        &ReleaseType::SafenodeManager,
+        SAFENODE_MANAGER_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenode_manager_for_windows() {
+    download_and_extract(
+        &ReleaseType::SafenodeManager,
+        SAFENODE_MANAGER_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -48,6 +48,17 @@ async fn should_get_latest_version_of_safenode_rpc_client() {
 }
 
 #[tokio::test]
+async fn should_get_latest_version_of_safenode_manager() {
+    let release_type = ReleaseType::SafenodeManager;
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
+    assert!(valid_semver_format(&version));
+}
+
+#[tokio::test]
 async fn should_get_latest_version_of_testnet() {
     let release_type = ReleaseType::Testnet;
     let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();


### PR DESCRIPTION
The main noteworthy thing here is that the node manager is in its own repository. This crate was originally setup to pull releases from the `safe_network` workspace repository, so at the moment the node manager is a bit of a special case. However, it could be the case that in the future we will pull binaries from more repositories. This change supports that.

The node manager is a single-crate repository, which makes it much easier to get the latest version: you can use the specific API for that, rather than processing the whole release list.