### PR TITLE
feat: support faucet releases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use zip::ZipArchive;
 const GITHUB_API_URL: &str = "https://api.github.com";
 const GITHUB_ORG_NAME: &str = "maidsafe";
 const GITHUB_REPO_NAME: &str = "safe_network";
+const FAUCET_S3_BASE_URL: &str = "https://sn-faucet.s3.eu-west-2.amazonaws.com";
 const SAFE_S3_BASE_URL: &str = "https://sn-cli.s3.eu-west-2.amazonaws.com";
 const SAFENODE_S3_BASE_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
 const SAFENODE_MANAGER_S3_BASE_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com";
@@ -36,6 +37,7 @@ const TESTNET_S3_BASE_URL: &str = "https://sn-testnet.s3.eu-west-2.amazonaws.com
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ReleaseType {
+    Faucet,
     Safe,
     Safenode,
     SafenodeManager,
@@ -49,6 +51,7 @@ impl fmt::Display for ReleaseType {
             f,
             "{}",
             match self {
+                ReleaseType::Faucet => "faucet",
                 ReleaseType::Safe => "safe",
                 ReleaseType::Safenode => "safenode",
                 ReleaseType::SafenodeManager => "safenode-manager",
@@ -62,7 +65,8 @@ impl fmt::Display for ReleaseType {
 impl ReleaseType {
     pub fn get_repo_name(&self) -> String {
         match &self {
-            ReleaseType::Safe
+            ReleaseType::Faucet
+            | ReleaseType::Safe
             | ReleaseType::Safenode
             | ReleaseType::SafenodeRpcClient
             | ReleaseType::Testnet => "safe_network".to_string(),
@@ -74,6 +78,7 @@ impl ReleaseType {
 lazy_static! {
     static ref RELEASE_TYPE_CRATE_NAME_MAP: HashMap<ReleaseType, &'static str> = {
         let mut m = HashMap::new();
+        m.insert(ReleaseType::Faucet, "sn_faucet");
         m.insert(ReleaseType::Safe, "sn_cli");
         m.insert(ReleaseType::Safenode, "sn_node");
         m.insert(ReleaseType::SafenodeManager, "sn-node-manager");
@@ -149,6 +154,7 @@ impl dyn SafeReleaseRepositoryInterface {
     pub fn default_config() -> Box<dyn SafeReleaseRepositoryInterface> {
         Box::new(SafeReleaseRepository {
             github_api_base_url: GITHUB_API_URL.to_string(),
+            faucet_base_url: FAUCET_S3_BASE_URL.to_string(),
             safe_base_url: SAFE_S3_BASE_URL.to_string(),
             safenode_base_url: SAFENODE_S3_BASE_URL.to_string(),
             safenode_manager_base_url: SAFENODE_MANAGER_S3_BASE_URL.to_string(),
@@ -160,6 +166,7 @@ impl dyn SafeReleaseRepositoryInterface {
 
 pub struct SafeReleaseRepository {
     pub github_api_base_url: String,
+    pub faucet_base_url: String,
     pub safe_base_url: String,
     pub safenode_base_url: String,
     pub safenode_manager_base_url: String,
@@ -170,6 +177,7 @@ pub struct SafeReleaseRepository {
 impl SafeReleaseRepository {
     fn get_base_url(&self, release_type: &ReleaseType) -> String {
         match release_type {
+            ReleaseType::Faucet => self.faucet_base_url.clone(),
             ReleaseType::Safe => self.safe_base_url.clone(),
             ReleaseType::Safenode => self.safenode_base_url.clone(),
             ReleaseType::SafenodeManager => self.safenode_manager_base_url.clone(),

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -11,6 +11,7 @@ use predicates::prelude::*;
 use sn_releases::error::Error;
 use sn_releases::{ArchiveType, Platform, ReleaseType, SafeReleaseRepositoryInterface};
 
+const FAUCET_VERSION: &str = "0.1.98";
 const SAFE_VERSION: &str = "0.83.51";
 const SAFENODE_VERSION: &str = "0.93.7";
 const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
@@ -49,6 +50,7 @@ async fn download_and_extract(
         .unwrap();
 
     let binary_name = match release_type {
+        ReleaseType::Faucet => "faucet",
         ReleaseType::Safe => "safe",
         ReleaseType::Safenode => "safenode",
         ReleaseType::SafenodeManager => "safenode-manager",
@@ -438,6 +440,75 @@ async fn should_download_and_extract_safenode_manager_for_windows() {
     download_and_extract(
         &ReleaseType::SafenodeManager,
         SAFENODE_MANAGER_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}
+
+///
+/// Faucet Tests
+///
+#[tokio::test]
+async fn should_download_and_extract_faucet_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::Faucet,
+        FAUCET_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_faucet_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::Faucet,
+        FAUCET_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_faucet_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::Faucet,
+        FAUCET_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_faucet_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::Faucet,
+        FAUCET_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_faucet_for_macos() {
+    download_and_extract(
+        &ReleaseType::Faucet,
+        FAUCET_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_faucet_for_windows() {
+    download_and_extract(
+        &ReleaseType::Faucet,
+        FAUCET_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -15,6 +15,17 @@ fn valid_semver_format(version: &str) -> bool {
 }
 
 #[tokio::test]
+async fn should_get_latest_version_of_faucet() {
+    let release_type = ReleaseType::Faucet;
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
+    assert!(valid_semver_format(&version));
+}
+
+#[tokio::test]
 async fn should_get_latest_version_of_safe() {
     let release_type = ReleaseType::Safe;
     let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();


### PR DESCRIPTION
The node manager will look to pull in the latest version of the faucet for running local networks, so we need to be able to obtain its releases. The faucet is another binary from the `safe_network` repo.