### PR TITLE
chore: remove testnet from release type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,16 +15,18 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("Cannot parse file name from the URL")]
     CannotParseFilenameFromUrl,
+    #[error("Unexpected response from crates.io: {0}")]
+    CratesIoResponseError(u16),
     #[error(transparent)]
     DateTimeParseError(#[from] chrono::ParseError),
     #[error("Could not convert API response header links to string")]
     HeaderLinksToStrError,
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
     #[error("Latest release not found for {0}")]
     LatestReleaseNotFound(String),
-    #[error("The Github API's latest release response document was not in the expected format")]
-    MalformedLatestReleaseResponse,
     #[error("{0}")]
     PlatformNotSupported(String),
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ const SAFENODE_S3_BASE_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
 const SAFENODE_MANAGER_S3_BASE_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com";
 const SAFENODE_RPC_CLIENT_S3_BASE_URL: &str =
     "https://sn-node-rpc-client.s3.eu-west-2.amazonaws.com";
-const TESTNET_S3_BASE_URL: &str = "https://sn-testnet.s3.eu-west-2.amazonaws.com";
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ReleaseType {
@@ -42,7 +41,6 @@ pub enum ReleaseType {
     Safenode,
     SafenodeManager,
     SafenodeRpcClient,
-    Testnet,
 }
 
 impl fmt::Display for ReleaseType {
@@ -56,7 +54,6 @@ impl fmt::Display for ReleaseType {
                 ReleaseType::Safenode => "safenode",
                 ReleaseType::SafenodeManager => "safenode-manager",
                 ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
-                ReleaseType::Testnet => "testnet",
             }
         )
     }
@@ -68,8 +65,7 @@ impl ReleaseType {
             ReleaseType::Faucet
             | ReleaseType::Safe
             | ReleaseType::Safenode
-            | ReleaseType::SafenodeRpcClient
-            | ReleaseType::Testnet => "safe_network".to_string(),
+            | ReleaseType::SafenodeRpcClient => "safe_network".to_string(),
             ReleaseType::SafenodeManager => "sn-node-manager".to_string(),
         }
     }
@@ -83,7 +79,6 @@ lazy_static! {
         m.insert(ReleaseType::Safenode, "sn_node");
         m.insert(ReleaseType::SafenodeManager, "sn-node-manager");
         m.insert(ReleaseType::SafenodeRpcClient, "sn_node_rpc_client");
-        m.insert(ReleaseType::Testnet, "sn_testnet");
         m
     };
 }
@@ -159,7 +154,6 @@ impl dyn SafeReleaseRepositoryInterface {
             safenode_base_url: SAFENODE_S3_BASE_URL.to_string(),
             safenode_manager_base_url: SAFENODE_MANAGER_S3_BASE_URL.to_string(),
             safenode_rpc_client_base_url: SAFENODE_RPC_CLIENT_S3_BASE_URL.to_string(),
-            testnet_base_url: TESTNET_S3_BASE_URL.to_string(),
         })
     }
 }
@@ -171,7 +165,6 @@ pub struct SafeReleaseRepository {
     pub safenode_base_url: String,
     pub safenode_manager_base_url: String,
     pub safenode_rpc_client_base_url: String,
-    pub testnet_base_url: String,
 }
 
 impl SafeReleaseRepository {
@@ -182,7 +175,6 @@ impl SafeReleaseRepository {
             ReleaseType::Safenode => self.safenode_base_url.clone(),
             ReleaseType::SafenodeManager => self.safenode_manager_base_url.clone(),
             ReleaseType::SafenodeRpcClient => self.safenode_rpc_client_base_url.clone(),
-            ReleaseType::Testnet => self.testnet_base_url.clone(),
         }
     }
 

--- a/tests/download_url.rs
+++ b/tests/download_url.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -16,7 +16,6 @@ const SAFE_VERSION: &str = "0.83.51";
 const SAFENODE_VERSION: &str = "0.93.7";
 const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
 const SAFENODE_RPC_CLIENT_VERSION: &str = "0.1.40";
-const TESTNET_VERSION: &str = "0.2.213";
 
 async fn download_and_extract(
     release_type: &ReleaseType,
@@ -55,7 +54,6 @@ async fn download_and_extract(
         ReleaseType::Safenode => "safenode",
         ReleaseType::SafenodeManager => "safenode-manager",
         ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
-        ReleaseType::Testnet => "testnet",
     };
     let expected_binary_name = if *platform == Platform::Windows {
         format!("{}.exe", binary_name)
@@ -233,75 +231,6 @@ async fn should_download_and_extract_safenode_for_windows() {
     download_and_extract(
         &ReleaseType::Safenode,
         SAFENODE_VERSION,
-        &Platform::Windows,
-        &ArchiveType::Zip,
-    )
-    .await;
-}
-
-///
-/// Testnet Tests
-///
-#[tokio::test]
-async fn should_download_and_extract_testnet_for_linux_musl() {
-    download_and_extract(
-        &ReleaseType::Testnet,
-        TESTNET_VERSION,
-        &Platform::LinuxMusl,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_testnet_for_linux_musl_aarch64() {
-    download_and_extract(
-        &ReleaseType::Testnet,
-        TESTNET_VERSION,
-        &Platform::LinuxMuslAarch64,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_testnet_for_linux_musl_arm() {
-    download_and_extract(
-        &ReleaseType::Testnet,
-        TESTNET_VERSION,
-        &Platform::LinuxMuslArm,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_testnet_for_linux_musl_arm_v7() {
-    download_and_extract(
-        &ReleaseType::Testnet,
-        TESTNET_VERSION,
-        &Platform::LinuxMuslArmV7,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_testnet_for_macos() {
-    download_and_extract(
-        &ReleaseType::Testnet,
-        TESTNET_VERSION,
-        &Platform::MacOs,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_testnet_for_windows() {
-    download_and_extract(
-        &ReleaseType::Testnet,
-        TESTNET_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -68,14 +68,3 @@ async fn should_get_latest_version_of_safenode_manager() {
         .unwrap();
     assert!(valid_semver_format(&version));
 }
-
-#[tokio::test]
-async fn should_get_latest_version_of_testnet() {
-    let release_type = ReleaseType::Testnet;
-    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
-    let version = release_repo
-        .get_latest_version(&release_type)
-        .await
-        .unwrap();
-    assert!(valid_semver_format(&version));
-}


### PR DESCRIPTION
- f0148e7 **chore: remove testnet from release type**

  This also deletes all the tests related to testnet, since we won't be supporting this binary any
  more.

- 6183f05 **refactor: retrieve latest release from crates.io**

  It's actually much simpler to use the `crates.io` API to obtain the latest version of a crate for a
  workspace repository, because it doesn't involve searching through various different types of Github
  releases.

- ef937e5 **chore: update license year**

  We know this is not required from a legal point of view, but the license verification tool works on
  the basis of the current year, so we need to update the files to get CI green.