### PR TITLE
feat: support safenodemand releases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub enum ReleaseType {
     Safe,
     Safenode,
     SafenodeManager,
+    SafenodeManagerDaemon,
     SafenodeRpcClient,
 }
 
@@ -50,6 +51,7 @@ impl fmt::Display for ReleaseType {
                 ReleaseType::Safe => "safe",
                 ReleaseType::Safenode => "safenode",
                 ReleaseType::SafenodeManager => "safenode-manager",
+                ReleaseType::SafenodeManagerDaemon => "safenodemand",
                 ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
             }
         )
@@ -63,6 +65,7 @@ lazy_static! {
         m.insert(ReleaseType::Safe, "sn_cli");
         m.insert(ReleaseType::Safenode, "sn_node");
         m.insert(ReleaseType::SafenodeManager, "sn-node-manager");
+        m.insert(ReleaseType::SafenodeManagerDaemon, "sn-node-manager");
         m.insert(ReleaseType::SafenodeRpcClient, "sn_node_rpc_client");
         m
     };
@@ -159,6 +162,7 @@ impl SafeReleaseRepository {
             ReleaseType::Safe => self.safe_base_url.clone(),
             ReleaseType::Safenode => self.safenode_base_url.clone(),
             ReleaseType::SafenodeManager => self.safenode_manager_base_url.clone(),
+            ReleaseType::SafenodeManagerDaemon => self.safenode_manager_base_url.clone(),
             ReleaseType::SafenodeRpcClient => self.safenode_rpc_client_base_url.clone(),
         }
     }

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -15,6 +15,7 @@ const FAUCET_VERSION: &str = "0.1.98";
 const SAFE_VERSION: &str = "0.83.51";
 const SAFENODE_VERSION: &str = "0.93.7";
 const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
+const SAFENODE_MANAGERD_VERSION: &str = "0.4.1";
 const SAFENODE_RPC_CLIENT_VERSION: &str = "0.1.40";
 
 async fn download_and_extract(
@@ -53,6 +54,7 @@ async fn download_and_extract(
         ReleaseType::Safe => "safe",
         ReleaseType::Safenode => "safenode",
         ReleaseType::SafenodeManager => "safenode-manager",
+        ReleaseType::SafenodeManagerDaemon => "safenodemand",
         ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
     };
     let expected_binary_name = if *platform == Platform::Windows {
@@ -436,6 +438,75 @@ async fn should_download_and_extract_faucet_for_windows() {
     download_and_extract(
         &ReleaseType::Faucet,
         FAUCET_VERSION,
+        &Platform::Windows,
+        &ArchiveType::Zip,
+    )
+    .await;
+}
+
+///
+/// Node Manager Daemon Tests
+///
+#[tokio::test]
+async fn should_download_and_extract_safenodemand_for_linux_musl() {
+    download_and_extract(
+        &ReleaseType::SafenodeManagerDaemon,
+        SAFENODE_MANAGERD_VERSION,
+        &Platform::LinuxMusl,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenodemand_for_linux_musl_aarch64() {
+    download_and_extract(
+        &ReleaseType::SafenodeManagerDaemon,
+        SAFENODE_MANAGERD_VERSION,
+        &Platform::LinuxMuslAarch64,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenodemand_for_linux_musl_arm() {
+    download_and_extract(
+        &ReleaseType::SafenodeManagerDaemon,
+        SAFENODE_MANAGERD_VERSION,
+        &Platform::LinuxMuslArm,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenodemand_for_linux_musl_arm_v7() {
+    download_and_extract(
+        &ReleaseType::SafenodeManagerDaemon,
+        SAFENODE_MANAGERD_VERSION,
+        &Platform::LinuxMuslArmV7,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenodemand_for_macos() {
+    download_and_extract(
+        &ReleaseType::SafenodeManagerDaemon,
+        SAFENODE_MANAGERD_VERSION,
+        &Platform::MacOs,
+        &ArchiveType::TarGz,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_download_and_extract_safenodemand_for_windows() {
+    download_and_extract(
+        &ReleaseType::SafenodeManagerDaemon,
+        SAFENODE_MANAGERD_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )

--- a/tests/test_get_latest_version.rs
+++ b/tests/test_get_latest_version.rs
@@ -68,3 +68,14 @@ async fn should_get_latest_version_of_safenode_manager() {
         .unwrap();
     assert!(valid_semver_format(&version));
 }
+
+#[tokio::test]
+async fn should_get_latest_version_of_safenodemand() {
+    let release_type = ReleaseType::SafenodeManagerDaemon;
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let version = release_repo
+        .get_latest_version(&release_type)
+        .await
+        .unwrap();
+    assert!(valid_semver_format(&version));
+}


### PR DESCRIPTION
The node manager will look to pull in the latest version of the node manager daemon, so we need to be able to obtain its releases.

This binary will shortly be renamed from `safenodemand`, probably to `safenodemgrd`. At that point, we'll need to come and update the repository again.