### PR TITLE
feat: validate the provided semantic version str

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     DateTimeParseError(#[from] chrono::ParseError),
     #[error("Could not convert API response header links to string")]
     HeaderLinksToStrError,
+    #[error("The version string is invalid: {0}")]
+    InvalidVersionFormat(String),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
@@ -29,6 +31,8 @@ pub enum Error {
     LatestReleaseNotFound(String),
     #[error("{0}")]
     PlatformNotSupported(String),
+    #[error("Could not compile the regex statement")]
+    RegexError,
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error("Release binary {0} was not found")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,13 @@ impl SafeReleaseRepositoryInterface for SafeReleaseRepository {
         dest_path: &Path,
         callback: &ProgressCallback,
     ) -> Result<PathBuf> {
+        // parse version str.
+        let version_pattern =
+            regex::Regex::new(r"^\d+\.\d+\.\d+$").map_err(|_| Error::RegexError)?;
+        if !version_pattern.is_match(version) {
+            return Err(Error::InvalidVersionFormat(version.to_string()));
+        }
+
         let archive_ext = archive_type.to_string();
         let url = format!(
             "{}/{}-{}-{}.{}",

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -67,7 +67,7 @@ async fn download_and_extract(
 }
 
 #[tokio::test]
-async fn should_fail_when_trying_to_download_invalid_combination() {
+async fn should_fail_when_trying_to_download_with_invalid_version() {
     let dest_dir = assert_fs::TempDir::new().unwrap();
     let download_dir = dest_dir.child("download_to");
     download_dir.create_dir_all().unwrap();
@@ -91,10 +91,8 @@ async fn should_fail_when_trying_to_download_invalid_combination() {
     match result {
         Ok(_) => panic!("This test should result in a failure"),
         Err(e) => match e {
-            Error::ReleaseBinaryNotFound(url) => {
-                assert_eq!(url, "https://sn-cli.s3.eu-west-2.amazonaws.com/safe-x.y.z-x86_64-unknown-linux-musl.tar.gz");
-            }
-            _ => panic!("The error type should be ReleaseBinaryNotFound"),
+            Error::InvalidVersionFormat(_) => {}
+            _ => panic!("The error type should be InvalidVersionFormat. Got {e:?}"),
         },
     }
 }


### PR DESCRIPTION
The `version` argument should preferably be a struct that provides validation during init. But that would be a breaking change and we might have to update alot of crates. This is a simple solution that gets the job done.