### PR TITLE
feat: provide `download_winsw` on release repository

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ const SAFENODE_MANAGER_S3_BASE_URL: &str = "https://sn-node-manager.s3.eu-west-2
 const SAFENODE_RPC_CLIENT_S3_BASE_URL: &str =
     "https://sn-node-rpc-client.s3.eu-west-2.amazonaws.com";
 const SN_AUDITOR_S3_BASE_URL: &str = "https://sn-auditor.s3.eu-west-2.amazonaws.com";
+const WINSW_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com/WinSW-x64.exe";
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ReleaseType {
@@ -143,6 +144,7 @@ pub trait SafeReleaseRepoActions {
         dest_dir_path: &Path,
         callback: &ProgressCallback,
     ) -> Result<PathBuf>;
+    async fn download_winsw(&self, dest_path: &Path, callback: &ProgressCallback) -> Result<()>;
     fn extract_release_archive(&self, archive_path: &Path, dest_dir_path: &Path)
         -> Result<PathBuf>;
 }
@@ -193,7 +195,7 @@ impl SafeReleaseRepository {
     async fn download_url(
         &self,
         url: &str,
-        dest_path: &PathBuf,
+        dest_path: &Path,
         callback: &ProgressCallback,
     ) -> Result<()> {
         let client = Client::new();
@@ -337,6 +339,11 @@ impl SafeReleaseRepoActions for SafeReleaseRepository {
         self.download_url(url, &dest_path, callback).await?;
 
         Ok(dest_path)
+    }
+
+    async fn download_winsw(&self, dest_path: &Path, callback: &ProgressCallback) -> Result<()> {
+        self.download_url(WINSW_URL, dest_path, callback).await?;
+        Ok(())
     }
 
     /// Extracts a release binary archive.

--- a/tests/download_url.rs
+++ b/tests/download_url.rs
@@ -11,6 +11,23 @@ use sn_releases::error::Error;
 use sn_releases::SafeReleaseRepoActions;
 
 #[tokio::test]
+async fn should_download_winsw() {
+    let dest_dir = assert_fs::TempDir::new().unwrap();
+    let download_dir = dest_dir.child("download_to");
+    download_dir.create_dir_all().unwrap();
+    let downloaded_archive = download_dir.child("WinSW-x64.exe");
+
+    let progress_callback = |_downloaded: u64, _total: u64| {};
+    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    release_repo
+        .download_winsw(&downloaded_archive, &progress_callback)
+        .await
+        .unwrap();
+
+    downloaded_archive.assert(predicates::path::is_file());
+}
+
+#[tokio::test]
 async fn should_download_a_custom_binary() {
     let dest_dir = assert_fs::TempDir::new().unwrap();
     let download_dir = dest_dir.child("download_to");


### PR DESCRIPTION
We need a quick mechanism in `node-launchpad` and `safenode-manager` for obtaining a copy of `WinSW` so that node services can be created and used on Windows.

The reason for putting it in this crate is because it would be shared between `safeup`, `safenode-manager` and `node-launchpad`.