### PR TITLE
feat: replace safe release type with autonomi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ use tokio::io::AsyncWriteExt;
 use zip::ZipArchive;
 
 const AUTONOMI_S3_BASE_URL: &str = "https://autonomi-cli.s3.eu-west-2.amazonaws.com";
-const FAUCET_S3_BASE_URL: &str = "https://sn-faucet.s3.eu-west-2.amazonaws.com";
 const GITHUB_API_URL: &str = "https://api.github.com";
 const NAT_DETECTION_S3_BASE_URL: &str = "https://nat-detection.s3.eu-west-2.amazonaws.com";
 const NODE_LAUNCHPAD_S3_BASE_URL: &str = "https://node-launchpad.s3.eu-west-2.amazonaws.com";
@@ -33,20 +32,17 @@ const SAFENODE_MANAGER_S3_BASE_URL: &str = "https://sn-node-manager.s3.eu-west-2
 const SAFENODE_RPC_CLIENT_S3_BASE_URL: &str =
     "https://sn-node-rpc-client.s3.eu-west-2.amazonaws.com";
 const SAFENODE_S3_BASE_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
-const SN_AUDITOR_S3_BASE_URL: &str = "https://sn-auditor.s3.eu-west-2.amazonaws.com";
 const WINSW_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com/WinSW-x64.exe";
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ReleaseType {
     Autonomi,
-    Faucet,
     NatDetection,
     NodeLaunchpad,
     Safenode,
     SafenodeManager,
     SafenodeManagerDaemon,
     SafenodeRpcClient,
-    SnAuditor,
 }
 
 impl fmt::Display for ReleaseType {
@@ -56,14 +52,12 @@ impl fmt::Display for ReleaseType {
             "{}",
             match self {
                 ReleaseType::Autonomi => "autonomi",
-                ReleaseType::Faucet => "faucet",
                 ReleaseType::NatDetection => "nat-detection",
                 ReleaseType::NodeLaunchpad => "node-launchpad",
                 ReleaseType::Safenode => "safenode",
                 ReleaseType::SafenodeManager => "safenode-manager",
                 ReleaseType::SafenodeManagerDaemon => "safenodemand",
                 ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
-                ReleaseType::SnAuditor => "sn_auditor",
             }
         )
     }
@@ -73,15 +67,12 @@ lazy_static! {
     static ref RELEASE_TYPE_CRATE_NAME_MAP: HashMap<ReleaseType, &'static str> = {
         let mut m = HashMap::new();
         m.insert(ReleaseType::Autonomi, "autonomi");
-        m.insert(ReleaseType::Faucet, "sn_faucet");
         m.insert(ReleaseType::NatDetection, "nat-detection");
         m.insert(ReleaseType::NodeLaunchpad, "node-launchpad");
         m.insert(ReleaseType::Safenode, "sn_node");
         m.insert(ReleaseType::SafenodeManager, "sn-node-manager");
         m.insert(ReleaseType::SafenodeManagerDaemon, "sn-node-manager");
         m.insert(ReleaseType::SafenodeRpcClient, "sn_node_rpc_client");
-        m.insert(ReleaseType::SnAuditor, "sn_auditor");
-
         m
     };
 }
@@ -156,33 +147,28 @@ impl dyn SafeReleaseRepoActions {
         Box::new(SafeReleaseRepository {
             github_api_base_url: GITHUB_API_URL.to_string(),
             nat_detection_base_url: NAT_DETECTION_S3_BASE_URL.to_string(),
-            faucet_base_url: FAUCET_S3_BASE_URL.to_string(),
             node_launchpad_base_url: NODE_LAUNCHPAD_S3_BASE_URL.to_string(),
             autonomi_base_url: AUTONOMI_S3_BASE_URL.to_string(),
             safenode_base_url: SAFENODE_S3_BASE_URL.to_string(),
             safenode_manager_base_url: SAFENODE_MANAGER_S3_BASE_URL.to_string(),
             safenode_rpc_client_base_url: SAFENODE_RPC_CLIENT_S3_BASE_URL.to_string(),
-            sn_auditor_base_url: SN_AUDITOR_S3_BASE_URL.to_string(),
         })
     }
 }
 
 pub struct SafeReleaseRepository {
     pub github_api_base_url: String,
-    pub faucet_base_url: String,
     pub nat_detection_base_url: String,
     pub node_launchpad_base_url: String,
     pub autonomi_base_url: String,
     pub safenode_base_url: String,
     pub safenode_manager_base_url: String,
     pub safenode_rpc_client_base_url: String,
-    pub sn_auditor_base_url: String,
 }
 
 impl SafeReleaseRepository {
     fn get_base_url(&self, release_type: &ReleaseType) -> String {
         match release_type {
-            ReleaseType::Faucet => self.faucet_base_url.clone(),
             ReleaseType::NatDetection => self.nat_detection_base_url.clone(),
             ReleaseType::NodeLaunchpad => self.node_launchpad_base_url.clone(),
             ReleaseType::Autonomi => self.autonomi_base_url.clone(),
@@ -190,7 +176,6 @@ impl SafeReleaseRepository {
             ReleaseType::SafenodeManager => self.safenode_manager_base_url.clone(),
             ReleaseType::SafenodeManagerDaemon => self.safenode_manager_base_url.clone(),
             ReleaseType::SafenodeRpcClient => self.safenode_rpc_client_base_url.clone(),
-            ReleaseType::SnAuditor => self.sn_auditor_base_url.clone(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,24 +24,24 @@ use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use zip::ZipArchive;
 
-const GITHUB_API_URL: &str = "https://api.github.com";
+const AUTONOMI_S3_BASE_URL: &str = "https://autonomi-cli.s3.eu-west-2.amazonaws.com";
 const FAUCET_S3_BASE_URL: &str = "https://sn-faucet.s3.eu-west-2.amazonaws.com";
+const GITHUB_API_URL: &str = "https://api.github.com";
 const NAT_DETECTION_S3_BASE_URL: &str = "https://nat-detection.s3.eu-west-2.amazonaws.com";
 const NODE_LAUNCHPAD_S3_BASE_URL: &str = "https://node-launchpad.s3.eu-west-2.amazonaws.com";
-const SAFE_S3_BASE_URL: &str = "https://sn-cli.s3.eu-west-2.amazonaws.com";
-const SAFENODE_S3_BASE_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
 const SAFENODE_MANAGER_S3_BASE_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com";
 const SAFENODE_RPC_CLIENT_S3_BASE_URL: &str =
     "https://sn-node-rpc-client.s3.eu-west-2.amazonaws.com";
+const SAFENODE_S3_BASE_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
 const SN_AUDITOR_S3_BASE_URL: &str = "https://sn-auditor.s3.eu-west-2.amazonaws.com";
 const WINSW_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com/WinSW-x64.exe";
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ReleaseType {
+    Autonomi,
     Faucet,
     NatDetection,
     NodeLaunchpad,
-    Safe,
     Safenode,
     SafenodeManager,
     SafenodeManagerDaemon,
@@ -55,10 +55,10 @@ impl fmt::Display for ReleaseType {
             f,
             "{}",
             match self {
+                ReleaseType::Autonomi => "autonomi",
                 ReleaseType::Faucet => "faucet",
                 ReleaseType::NatDetection => "nat-detection",
                 ReleaseType::NodeLaunchpad => "node-launchpad",
-                ReleaseType::Safe => "safe",
                 ReleaseType::Safenode => "safenode",
                 ReleaseType::SafenodeManager => "safenode-manager",
                 ReleaseType::SafenodeManagerDaemon => "safenodemand",
@@ -72,10 +72,10 @@ impl fmt::Display for ReleaseType {
 lazy_static! {
     static ref RELEASE_TYPE_CRATE_NAME_MAP: HashMap<ReleaseType, &'static str> = {
         let mut m = HashMap::new();
+        m.insert(ReleaseType::Autonomi, "autonomi");
         m.insert(ReleaseType::Faucet, "sn_faucet");
         m.insert(ReleaseType::NatDetection, "nat-detection");
         m.insert(ReleaseType::NodeLaunchpad, "node-launchpad");
-        m.insert(ReleaseType::Safe, "sn_cli");
         m.insert(ReleaseType::Safenode, "sn_node");
         m.insert(ReleaseType::SafenodeManager, "sn-node-manager");
         m.insert(ReleaseType::SafenodeManagerDaemon, "sn-node-manager");
@@ -158,7 +158,7 @@ impl dyn SafeReleaseRepoActions {
             nat_detection_base_url: NAT_DETECTION_S3_BASE_URL.to_string(),
             faucet_base_url: FAUCET_S3_BASE_URL.to_string(),
             node_launchpad_base_url: NODE_LAUNCHPAD_S3_BASE_URL.to_string(),
-            safe_base_url: SAFE_S3_BASE_URL.to_string(),
+            autonomi_base_url: AUTONOMI_S3_BASE_URL.to_string(),
             safenode_base_url: SAFENODE_S3_BASE_URL.to_string(),
             safenode_manager_base_url: SAFENODE_MANAGER_S3_BASE_URL.to_string(),
             safenode_rpc_client_base_url: SAFENODE_RPC_CLIENT_S3_BASE_URL.to_string(),
@@ -172,7 +172,7 @@ pub struct SafeReleaseRepository {
     pub faucet_base_url: String,
     pub nat_detection_base_url: String,
     pub node_launchpad_base_url: String,
-    pub safe_base_url: String,
+    pub autonomi_base_url: String,
     pub safenode_base_url: String,
     pub safenode_manager_base_url: String,
     pub safenode_rpc_client_base_url: String,
@@ -185,7 +185,7 @@ impl SafeReleaseRepository {
             ReleaseType::Faucet => self.faucet_base_url.clone(),
             ReleaseType::NatDetection => self.nat_detection_base_url.clone(),
             ReleaseType::NodeLaunchpad => self.node_launchpad_base_url.clone(),
-            ReleaseType::Safe => self.safe_base_url.clone(),
+            ReleaseType::Autonomi => self.autonomi_base_url.clone(),
             ReleaseType::Safenode => self.safenode_base_url.clone(),
             ReleaseType::SafenodeManager => self.safenode_manager_base_url.clone(),
             ReleaseType::SafenodeManagerDaemon => self.safenode_manager_base_url.clone(),

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -14,7 +14,7 @@ use sn_releases::{ArchiveType, Platform, ReleaseType, SafeReleaseRepoActions};
 const FAUCET_VERSION: &str = "0.1.98";
 const NAT_DETECTION_VERSION: &str = "0.1.0";
 const NODE_LAUNCHPAD_VERSION: &str = "0.1.0";
-const SAFE_VERSION: &str = "0.94.0";
+const AUTONOMI_VERSION: &str = "1.0.0";
 const SAFENODE_VERSION: &str = "0.93.7";
 const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
 const SAFENODE_MANAGERD_VERSION: &str = "0.4.1";
@@ -56,7 +56,7 @@ async fn download_and_extract(
         ReleaseType::Faucet => "faucet",
         ReleaseType::NatDetection => "nat-detection",
         ReleaseType::NodeLaunchpad => "node-launchpad",
-        ReleaseType::Safe => "safe",
+        ReleaseType::Autonomi => "autonomi",
         ReleaseType::Safenode => "safenode",
         ReleaseType::SafenodeManager => "safenode-manager",
         ReleaseType::SafenodeManagerDaemon => "safenodemand",
@@ -75,13 +75,13 @@ async fn download_and_extract(
 }
 
 ///
-/// Safe Tests
+/// Autonomi Tests
 ///
 #[tokio::test]
-async fn should_download_and_extract_safe_for_linux_musl() {
+async fn should_download_and_extract_autonomi_for_linux_musl() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::LinuxMusl,
         &ArchiveType::TarGz,
     )
@@ -89,10 +89,10 @@ async fn should_download_and_extract_safe_for_linux_musl() {
 }
 
 #[tokio::test]
-async fn should_download_and_extract_safe_for_linux_musl_aarch64() {
+async fn should_download_and_extract_autonomi_for_linux_musl_aarch64() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::LinuxMuslAarch64,
         &ArchiveType::TarGz,
     )
@@ -100,10 +100,10 @@ async fn should_download_and_extract_safe_for_linux_musl_aarch64() {
 }
 
 #[tokio::test]
-async fn should_download_and_extract_safe_for_linux_musl_arm() {
+async fn should_download_and_extract_autonomi_for_linux_musl_arm() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::LinuxMuslArm,
         &ArchiveType::TarGz,
     )
@@ -111,10 +111,10 @@ async fn should_download_and_extract_safe_for_linux_musl_arm() {
 }
 
 #[tokio::test]
-async fn should_download_and_extract_safe_for_linux_musl_arm_v7() {
+async fn should_download_and_extract_autonomi_for_linux_musl_arm_v7() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::LinuxMuslArmV7,
         &ArchiveType::TarGz,
     )
@@ -122,10 +122,10 @@ async fn should_download_and_extract_safe_for_linux_musl_arm_v7() {
 }
 
 #[tokio::test]
-async fn should_download_and_extract_safe_for_macos() {
+async fn should_download_and_extract_autonomi_for_macos() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::MacOs,
         &ArchiveType::TarGz,
     )
@@ -133,10 +133,10 @@ async fn should_download_and_extract_safe_for_macos() {
 }
 
 #[tokio::test]
-async fn should_download_and_extract_safe_for_macos_aarch64() {
+async fn should_download_and_extract_autonomi_for_macos_aarch64() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::MacOsAarch64,
         &ArchiveType::TarGz,
     )
@@ -144,10 +144,10 @@ async fn should_download_and_extract_safe_for_macos_aarch64() {
 }
 
 #[tokio::test]
-async fn should_download_and_extract_safe_for_windows() {
+async fn should_download_and_extract_autonomi_for_windows() {
     download_and_extract(
-        &ReleaseType::Safe,
-        SAFE_VERSION,
+        &ReleaseType::Autonomi,
+        AUTONOMI_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -11,7 +11,6 @@ use predicates::prelude::*;
 use semver::Version;
 use sn_releases::{ArchiveType, Platform, ReleaseType, SafeReleaseRepoActions};
 
-const FAUCET_VERSION: &str = "0.1.98";
 const NAT_DETECTION_VERSION: &str = "0.1.0";
 const NODE_LAUNCHPAD_VERSION: &str = "0.1.0";
 const AUTONOMI_VERSION: &str = "1.0.0";
@@ -19,7 +18,6 @@ const SAFENODE_VERSION: &str = "0.93.7";
 const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
 const SAFENODE_MANAGERD_VERSION: &str = "0.4.1";
 const SAFENODE_RPC_CLIENT_VERSION: &str = "0.1.40";
-const SN_AUDITOR_VERSION: &str = "0.1.16";
 
 async fn download_and_extract(
     release_type: &ReleaseType,
@@ -53,15 +51,13 @@ async fn download_and_extract(
         .unwrap();
 
     let binary_name = match release_type {
-        ReleaseType::Faucet => "faucet",
+        ReleaseType::Autonomi => "autonomi",
         ReleaseType::NatDetection => "nat-detection",
         ReleaseType::NodeLaunchpad => "node-launchpad",
-        ReleaseType::Autonomi => "autonomi",
         ReleaseType::Safenode => "safenode",
         ReleaseType::SafenodeManager => "safenode-manager",
         ReleaseType::SafenodeManagerDaemon => "safenodemand",
         ReleaseType::SafenodeRpcClient => "safenode_rpc_client",
-        ReleaseType::SnAuditor => "sn_auditor",
     };
     let expected_binary_name = if *platform == Platform::Windows {
         format!("{}.exe", binary_name)
@@ -362,75 +358,6 @@ async fn should_download_and_extract_safenode_manager_for_windows() {
 }
 
 ///
-/// Faucet Tests
-///
-#[tokio::test]
-async fn should_download_and_extract_faucet_for_linux_musl() {
-    download_and_extract(
-        &ReleaseType::Faucet,
-        FAUCET_VERSION,
-        &Platform::LinuxMusl,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_faucet_for_linux_musl_aarch64() {
-    download_and_extract(
-        &ReleaseType::Faucet,
-        FAUCET_VERSION,
-        &Platform::LinuxMuslAarch64,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_faucet_for_linux_musl_arm() {
-    download_and_extract(
-        &ReleaseType::Faucet,
-        FAUCET_VERSION,
-        &Platform::LinuxMuslArm,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_faucet_for_linux_musl_arm_v7() {
-    download_and_extract(
-        &ReleaseType::Faucet,
-        FAUCET_VERSION,
-        &Platform::LinuxMuslArmV7,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_faucet_for_macos() {
-    download_and_extract(
-        &ReleaseType::Faucet,
-        FAUCET_VERSION,
-        &Platform::MacOs,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_faucet_for_windows() {
-    download_and_extract(
-        &ReleaseType::Faucet,
-        FAUCET_VERSION,
-        &Platform::Windows,
-        &ArchiveType::Zip,
-    )
-    .await;
-}
-
-///
 /// Node Manager Daemon Tests
 ///
 #[tokio::test]
@@ -562,75 +489,6 @@ async fn should_download_and_extract_node_launchpad_for_windows() {
     download_and_extract(
         &ReleaseType::NodeLaunchpad,
         NODE_LAUNCHPAD_VERSION,
-        &Platform::Windows,
-        &ArchiveType::Zip,
-    )
-    .await;
-}
-
-///
-/// Sn Auditor Test
-///
-#[tokio::test]
-async fn should_download_and_extract_sn_auditor_for_linux_musl() {
-    download_and_extract(
-        &ReleaseType::SnAuditor,
-        SN_AUDITOR_VERSION,
-        &Platform::LinuxMusl,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_sn_auditor_for_linux_musl_aarch64() {
-    download_and_extract(
-        &ReleaseType::SnAuditor,
-        SN_AUDITOR_VERSION,
-        &Platform::LinuxMuslAarch64,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_sn_auditor_for_linux_musl_arm() {
-    download_and_extract(
-        &ReleaseType::SnAuditor,
-        SN_AUDITOR_VERSION,
-        &Platform::LinuxMuslArm,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_sn_auditor_for_linux_musl_arm_v7() {
-    download_and_extract(
-        &ReleaseType::SnAuditor,
-        SN_AUDITOR_VERSION,
-        &Platform::LinuxMuslArmV7,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_sn_auditor_for_macos() {
-    download_and_extract(
-        &ReleaseType::SnAuditor,
-        SN_AUDITOR_VERSION,
-        &Platform::MacOs,
-        &ArchiveType::TarGz,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn should_download_and_extract_sn_auditor_for_windows() {
-    download_and_extract(
-        &ReleaseType::SnAuditor,
-        SN_AUDITOR_VERSION,
         &Platform::Windows,
         &ArchiveType::Zip,
     )


### PR DESCRIPTION
- f5d0156 **feat: replace safe release type with autonomi**

  The `ReleaseType::Safe` variant is replaced with `ReleaseType::Autonomi`.

  The integration tests here won't work until the first stable release of the binary. They can be
  fixed for the next publish.

- bb965ac **chore: remove faucet and auditor release types**

  These releases do not apply for the EVM-based network.