### PR TITLE
fix: use correct crate name for autonomi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl fmt::Display for ReleaseType {
 lazy_static! {
     static ref RELEASE_TYPE_CRATE_NAME_MAP: HashMap<ReleaseType, &'static str> = {
         let mut m = HashMap::new();
-        m.insert(ReleaseType::Autonomi, "autonomi");
+        m.insert(ReleaseType::Autonomi, "autonomi-cli");
         m.insert(ReleaseType::NatDetection, "nat-detection");
         m.insert(ReleaseType::NodeLaunchpad, "node-launchpad");
         m.insert(ReleaseType::Safenode, "sn_node");

--- a/tests/test_download_from_s3.rs
+++ b/tests/test_download_from_s3.rs
@@ -13,7 +13,7 @@ use sn_releases::{ArchiveType, Platform, ReleaseType, SafeReleaseRepoActions};
 
 const NAT_DETECTION_VERSION: &str = "0.1.0";
 const NODE_LAUNCHPAD_VERSION: &str = "0.1.0";
-const AUTONOMI_VERSION: &str = "1.0.0";
+const AUTONOMI_VERSION: &str = "0.1.1";
 const SAFENODE_VERSION: &str = "0.93.7";
 const SAFENODE_MANAGER_VERSION: &str = "0.1.8";
 const SAFENODE_MANAGERD_VERSION: &str = "0.4.1";


### PR DESCRIPTION
The crate for the API was being used, rather than the CLI.